### PR TITLE
Mitigates SSRF vulnerability

### DIFF
--- a/beeping.go
+++ b/beeping.go
@@ -114,7 +114,7 @@ func handlercheck(c *gin.Context) {
 	}
 }
 
-// CheckHTTP do HTTP check and return a beeping reponse
+// CheckHTTP do HTTP check and return a beeping response
 func CheckHTTP(check *Check) (*Response, error) {
 	var response = NewResponse()
 	var conn net.Conn

--- a/beeping.go
+++ b/beeping.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.3.0"
+var VERSION = "0.4.0"
 var MESSAGE = "BeePing instance - HTTP Ping as a Service (github.com/yanc0/beeping)"
 var geodatfile *string
 var instance *string

--- a/beeping.go
+++ b/beeping.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -103,6 +104,16 @@ func handlerdefault(c *gin.Context) {
 func handlercheck(c *gin.Context) {
 	var check = NewCheck()
 	if c.BindJSON(&check) == nil {
+		// Check for local URLs
+		regexbadurl, err := regexp.Compile(`((http://)|(https://))((127\.)|(10\.)|(172\.1[6-9]\.)|(172\.2[0-9]\.)|(172\.3[0-1]\.)|(192\.168\.))`)
+		if err != nil {
+			log.Println(err.Error())
+			return
+		}
+		if regexbadurl.MatchString(check.URL) {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "disallowed IP address"})
+			return
+		}
 		response, err := CheckHTTP(check)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})


### PR DESCRIPTION
Mitigates a server-side request forgery (SSRF; [CWE-918](https://cwe.mitre.org/data/definitions/918.html)) security vulnerability in the application.

### Vulnerability details
SSRF occurs when an attacker can make a request through your server to other external servers. It can hide the attacker's origin IP from the targeted server, allowing for attackers to better cover their tracks. This is because all requests will appear to be coming from the BeePing server, rather than the attacker. SSRF also allows an attacker to enumerate accessible systems. In this particular instance, an attacker would be able to scan internal IP addresses through the BeePing server, which would otherwise be inaccessible from the internet. The BeePing server would essentially act as a proxy between the internet and the local network. In this case, it is somewhat mitigated by the fact that `http.client` only allows for requests using the "http://" and "https://" protocol schemes (and not things like "file://" or "ssh://", which would be far more dangerous). However, due to the fact that any system running BeePing is open to external connections ( #9 ), any system running BeePing would be vulnerable to this attack, opening up internal web servers (on any port, due to the fact that ports can be specified in the URL format with `http.client` as well) to be discovered by attackers; this information can be leveraged by attackers in further network penetration efforts.

Example of successful internal IP address scan:
<img width="666" alt="beeping internal ip scan" src="https://cloud.githubusercontent.com/assets/2362857/25748931/de4523d8-317a-11e7-89e6-db6f055e865d.png">

### Mitigation details
Due to the nature of this application, SSRF attacks can never truly be prevented- the application is intended to make outbound requests for users. However, the effects against the organization running an instance of BeePing have been mitigated by removing the ability of a user to scan internal IPv4 addresses (see [RFC 1918](https://tools.ietf.org/html/rfc1918)). **Note that internal IPv6 addresses have not been addressed by this pull request.** A further mitigation would be to set the service to listen on a local loopback interface only, rather than being open to external connections (see #9 for more details).

Cheers,
Aaron