### PR TITLE
correct parameter of geoip2.Open() in geoIPCountry()

### DIFF
--- a/beeping.go
+++ b/beeping.go
@@ -242,7 +242,7 @@ func milliseconds(d time.Duration) int64 {
 }
 
 func geoIPCountry(geodatabase string, ip string, response *Response) error {
-	db, err := geoip2.Open(*geodatfile)
+	db, err := geoip2.Open(geodatabase)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
correct parameter of geoip2.Open() in geoIPCountry() from “*geodatfile” to “geodatabase” because this function refers to global variable instead of parameter of geoIPCountry().