### PR TITLE
SSRF mitigation

### DIFF
--- a/beeping.go
+++ b/beeping.go
@@ -3,10 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"github.com/gin-gonic/gin"
-	"github.com/oschwald/geoip2-golang"
-	"github.com/tcnksm/go-httpstat"
-	"github.com/yanc0/beeping/sslcheck"
 	"io/ioutil"
 	"log"
 	"net"
@@ -15,6 +11,11 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/oschwald/geoip2-golang"
+	"github.com/tcnksm/go-httpstat"
+	"github.com/yanc0/beeping/sslcheck"
 )
 
 var VERSION = "0.5.0"
@@ -59,7 +60,7 @@ type Response struct {
 	HTTPStatus      string `json:"http_status"`
 	HTTPStatusCode  int    `json:"http_status_code"`
 	HTTPBodyPattern bool   `json:"http_body_pattern"`
-	HTTPHeader	bool   `json:"http_header"`
+	HTTPHeader      bool   `json:"http_header"`
 	HTTPRequestTime int64  `json:"http_request_time"`
 
 	InstanceName string `json:"instance_name"`


### PR DESCRIPTION
### Overview

Mitigates a server-side request forgery (SSRF; [CWE-918](https://cwe.mitre.org/data/definitions/918.html)) security vulnerability in the application.

### Vulnerability details
SSRF occurs when an attacker can make a request through your server to other external servers. It can hide the attacker's origin IP from the targeted server, allowing for attackers to better cover their tracks. This is because all requests will appear to be coming from the BeePing server, rather than the attacker. SSRF also allows an attacker to enumerate accessible systems. In this particular instance, an attacker would be able to scan internal IP addresses through the BeePing server, which would otherwise be inaccessible from the internet. The BeePing server would essentially act as a proxy between the internet and the local network. In this case, it is somewhat mitigated by the fact that `http.client` only allows for requests using the "http://" and "https://" protocol schemes (and not things like "file://" or "ssh://", which would be far more dangerous; these protocols could be added using a custom transport, but I won't get into that here. See https://golang.org/pkg/net/http/#Transport.RegisterProtocol if you really want to do that). However, due to the fact that any system running BeePing is open to external connections ( #9 ), any system running BeePing would be vulnerable to this attack, opening up internal web servers (on any port, due to the fact that ports can be specified in the URL format with `http.client` as well) to be discovered by attackers; this information can be leveraged by attackers in further network penetration efforts.

Example of successful internal IP address scan:
<img width="666" alt="beeping internal ip scan" src="https://cloud.githubusercontent.com/assets/2362857/25748931/de4523d8-317a-11e7-89e6-db6f055e865d.png">

### Mitigation details
Due to the nature of this application, SSRF attacks can never truly be prevented- the application is intended to make outbound requests for users. However, the effects against the organization running an instance of BeePing have been mitigated by removing the ability of a user to scan internal IPv4 and IPv6 addresses (see [RFC 1918](https://tools.ietf.org/html/rfc1918) for IPv4 and [RFC 4193](https://tools.ietf.org/html/rfc4193) for IPv6).

### What's included

See the following check list from #10: 

- [X] Fetch master
- [X] Fix conflicts
- [X] Add net/ip package instead of Regex
- [ ] Maybe Use IP from conn instead of check? (https://github.com/insp3ctre/beeping/blob/384219a12694b060bd352f953bea17207c1b140a/beeping.go#L204)
- [x] Add Bool command line flag that disable your feature
- [X] (Optional) IPv6 support

The IP could not be taken from `conn`, because that would have been too late, and the request would have already occurred (see https://github.com/yanc0/beeping/pull/10#issuecomment-300167142). Unfortunately, the [nested if statements](https://github.com/yanc0/beeping/compare/master...insp3ctre:SSRF_Mitigation?expand=1#diff-ae11c7c30b179041673ac7c811b78bc7R167) in the logic are needed, because I don't want to run the `validate()` method to check for an error if it hasn't been explicitly set in the command line options; otherwise, it'll incorporate more processing than is needed.

Cheers,
Aaron